### PR TITLE
feat(postgres): Admin username in Azure is not equal to the role name

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -23,10 +23,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check Code Style
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0 ## https://github.com/golangci/golangci-lint/releases
-          args: --timeout 3m0s
+          version: v1.51.2
 
   unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
+          args: --timeout 5m0s
 
   unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/image-publish.yaml
+++ b/.github/workflows/image-publish.yaml
@@ -1,139 +1,58 @@
-name: Publish Docker image
+name: Continuouos Delivery
 
 on:
   release:
-    types: [published, edited]
+    types: [published]
 
 env:
-  dockerhub_namespace: kloeckneri
-  manufacturer: kloeckner-i
-  product_name: db-operator
-  go_version: "1.17"
-  go_os: linux
-  main_go_path: .
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - go_arch: "amd64"
-            docker_arch: "amd64"
-          - go_arch: "arm64"
-            docker_arch: "arm64/v8"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+    permissions:
+      contents: read
+      packages: write
 
-      - name: Setup go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.go_version }}
-      
-      - name: Compile Binary
-        env:
-          GOOS: ${{ env.go_os }}
-          GOARCH: ${{ matrix.go_arch }}
-          CGO_ENABLED: "0"
-        run: |
-          go build -tags build -o ${{ env.product_name }} ${{ env.main_go_path }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.1.0
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Dockerhub
-        uses: docker/login-action@v1
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.3.0
         with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Set action link variable
-        run: echo "LINK=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_ENV
-
-      - name: Build and export
-        uses: docker/build-push-action@v3
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4.0.0
         with:
-          push: true
           context: .
-          file: Dockerfile-ci
-          platforms: ${{ env.go_os }}/${{ matrix.docker_arch }}
-          tags: |
-            ${{ env.dockerhub_namespace }}/${{ env.product_name }}:latest-${{ matrix.go_arch }}
-            ${{ env.dockerhub_namespace }}/${{ env.product_name }}:${{ github.event.release.tag_name }}-${{ matrix.go_arch }}
-            ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}:latest-${{ matrix.go_arch }}
-            ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}:${{ github.event.release.tag_name }}-${{ matrix.go_arch }}
-          labels: |
-            action_link=${{ env.LINK }}
-            actor=${{ github.actor }}
-            sha=${{ github.sha }}
-            ref=${{ github.ref }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
-  push_to_ghcr:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create a docker manifest for a versioned container
-        run: |
-          docker manifest create ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}:${{ github.event.release.tag_name }} \
-            --amend ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}:${{ github.event.release.tag_name }}-amd64 \
-            --amend ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}:${{ github.event.release.tag_name }}-arm64
-
-      - name: Create a manifest for the latest container
-        run: |
-          docker manifest create ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}:latest \
-            --amend ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}:latest-amd64 \
-            --amend ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}:latest-arm64
-
-      - name: Push the manifest
-        run: |
-          docker manifest push ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}:${{ github.event.release.tag_name }}
-          docker manifest push ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}:latest 
-
-  push_to_dockerhub:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Create a docker manifest for a versioned container
-        run: |
-          docker manifest create ${{ env.dockerhub_namespace }}/${{ env.product_name }}:${{ github.event.release.tag_name }} \
-            --amend ${{ env.dockerhub_namespace }}/${{ env.product_name }}:${{ github.event.release.tag_name }}-amd64 \
-            --amend ${{ env.dockerhub_namespace }}/${{ env.product_name }}:${{ github.event.release.tag_name }}-arm64
-
-      - name: Create a manifest for the latest container
-        run: |
-          docker manifest create ${{ env.dockerhub_namespace }}/${{ env.product_name }}:latest \
-            --amend ${{ env.dockerhub_namespace }}/${{ env.product_name }}:latest-amd64 \
-            --amend ${{ env.dockerhub_namespace }}/${{ env.product_name }}:latest-arm64
-
-      - name: Push the manifest
-        run: |
-          docker manifest push ${{ env.dockerhub_namespace }}/${{ env.product_name }}:${{ github.event.release.tag_name }}
-          docker manifest push ${{ env.dockerhub_namespace }}/${{ env.product_name }}:latest 
-
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          format: "table"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"

--- a/pkg/utils/database/postgres.go
+++ b/pkg/utils/database/postgres.go
@@ -270,7 +270,7 @@ func (p Postgres) checkSchemas() error {
 }
 
 func (p Postgres) deleteDatabase(admin AdminCredentials) error {
-	revoke := fmt.Sprintf("REVOKE CONNECT ON DATABASE \"%s\" FROM PUBLIC, \"%s\";", p.Database, admin.Username)
+	revoke := fmt.Sprintf("REVOKE CONNECT ON DATABASE \"%s\" FROM PUBLIC;", p.Database)
 	delete := fmt.Sprintf("DROP DATABASE \"%s\";", p.Database)
 
 	if p.isDbExist(admin) {


### PR DESCRIPTION
The Azure username for managed postgresql is required to have the form `user@host` however this is not compatible with revoking the connect privilege on the database before deleting. Furthermore the admin used should not be connected to the "user" databases anyway.